### PR TITLE
Fixed some spelling mistakes 

### DIFF
--- a/docs/0100-Install-and-Running/0100-Running-Lift.md
+++ b/docs/0100-Install-and-Running/0100-Running-Lift.md
@@ -9,18 +9,18 @@ You want to install and run Lift on your computer.
 Solution
 ---------
 
-The only prerequisite for installing and runing Lift is to have Java 1.5 or later installed.  Instructions for installing Java can be found at [java.com](http://java.com/en/download/manual.jsp).
+The only prerequisite for installing and running Lift is to have Java 1.5 or later installed.  Instructions for installing Java can be found at [java.com](http://java.com/en/download/manual.jsp).
 
-Once you have Java, the following instructuions will download, build and start a basic Lift application.
+Once you have Java, the following instructions will download, build and start a basic Lift application.
 
 ### for Mac and Linux ###
 
 * Download: [https://github.com/d6y/lift_24_sbt/zipball/master](https://github.com/d6y/lift_24_sbt/zipball/master)
-* Unzip the file.
-* Start Terminal or your favourite shell tool.
+* Unzip the file
+* Start Terminal or your favourite shell tool
 * Naviate into the unzipped folder
 * Run:`./sbt` 
-* Required libraries will be downloaded.
+* Required libraries will be downloaded
 * At the SBT prompt (>) type: `container:start`
 * Start your browser and go to `http://127.0.0.1:8080/`
 
@@ -28,10 +28,10 @@ Once you have Java, the following instructuions will download, build and start a
 ### for Windows ###
 
 * Download: [https://github.com/d6y/lift_24_sbt/zipball/master](https://github.com/d6y/lift_24_sbt/zipball/master)
-* Unzip the file.
+* Unzip the file
 * ?
 * Run:`./sbt.bat` 
-* Required libraries will be downloaded.
+* Required libraries will be downloaded
 * At the SBT prompt (>) type: `container:start`
 * Start your browser and go to `http://127.0.0.1:8080/`
 
@@ -47,7 +47,7 @@ The result of the above commands should be a basic Lift app running on your comp
 Discussion
 ----------
 
-Lift isn't installed in the usual sense of "installing software".  Instead it uses standard build tools, such as SBT or Maven, to assemble your application built with the Lift framework. This recipe has downloaded a bare-bones Lift applications, and then started it using a build tool.
+Lift isn't installed in the usual sense of "installing software".  Instead it uses standard build tools, such as SBT or Maven, to assemble your application built with the Lift framework. This recipe has downloaded a bare-bones Lift application, and then started it using a build tool.
 
 The `sbt` command starts the Simple Build Tool, a dependency management tool used by Scala projects.  It will check the project and download any libraries required by this Lift application.  The command `container:start` starts the web server on port 8080 (by default) and passes requests to the Lift application.
 


### PR DESCRIPTION
Removed . from list items - these weren't used consistently, even ignoring the fact some have code endings, so removed
