### PR TITLE
Spelling/grammar updates

### DIFF
--- a/docs/0500-Around/0110-Authenticated-Email.md
+++ b/docs/0500-Around/0110-Authenticated-Email.md
@@ -4,7 +4,7 @@ Sending authenticated email
 Problem
 -------
 
-You need to authenticated with an SMTP server to send email.
+You need to authenticate with an SMTP server to send email.
 
 Solution
 --------
@@ -37,9 +37,9 @@ mail.smtp.host=smtp.sendgrid.net
 Discussion
 ----------
 
-We've used Lift properties as a way to configure SMTP authentication.  This has the benefit of allow us to enable authentication for just some run modes.  For example, if our `default.props` did not contain authentication settings, but our `production.default.props` did, then no authentication would happen in development mode, ensuring we can't accidentally send email outside of a production environment.
+We've used Lift properties as a way to configure SMTP authentication.  This has the benefit of allowing us to enable authentication for just some run modes.  For example, if our `default.props` did not contain authentication settings, but our `production.default.props` did, then no authentication would happen in development mode, ensuring we can't accidentally send email outside of a production environment.
 
-But you don't have to use properties file for this (the Lift Mailer also supports JNDI). However, some mail services do require `mail.smtp.auth=true` to be set.
+But you don't have to use a properties file for this (the Lift Mailer also supports JNDI). However, some mail services do require `mail.smtp.auth=true` to be set.
 
 
 See Also


### PR DESCRIPTION
Changed 'authenticated' to 'authenticate' 
Changed 'allow' to 'allowing'
Added 'a' before properties - could instead be the but thought a made more sense
